### PR TITLE
Support Java 9 modules specific JVM arguments

### DIFF
--- a/capsule/src/test/java/CapsuleTest.java
+++ b/capsule/src/test/java/CapsuleTest.java
@@ -647,6 +647,29 @@ public class CapsuleTest {
     }
 
     @Test
+    public void testJava9JVMArgs() throws Exception {
+        props.setProperty("capsule.jvm.args", "--add-opens=java.base/java.security=ALL-UNNAMED --add-exports java.base/java.lang=ALL-UNNAMED");
+
+        Jar jar = newCapsuleJar()
+            .setAttribute("Application-Class", "com.acme.Foo")
+            .setAttribute("JVM-Args", "--add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED")
+            .addEntry("foo.jar", emptyInputStream());
+
+        List<String> args = list("hi", "there");
+        List<String> cmdLine = list("--add-exports=java.base/java.nio=ALL-UNNAMED");
+
+        Capsule capsule = newCapsule(jar);
+        ProcessBuilder pb = capsule.prepareForLaunch(cmdLine, args);
+
+        assert_().that(getJvmArgs(pb)).containsSequence(list(
+            "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+            "--add-opens=java.base/java.net=ALL-UNNAMED",
+            "--add-opens=java.base/java.security=ALL-UNNAMED",
+            "--add-exports=java.base/java.lang=ALL-UNNAMED",
+            "--add-exports=java.base/java.nio=ALL-UNNAMED"));
+    }
+
+    @Test
     public void testAgents() throws Exception {
         Jar jar = newCapsuleJar()
                 .setAttribute("Application-Class", "com.acme.Foo")


### PR DESCRIPTION
--add-modules, --add-reads, --add-exports and --add-opens can be
followed by a space and the module/package it applies to. This pair is
split when parsing arguments and should be recombined together.
- Add a new method addJava9ModulesJvmArg with a state variable
firstPartJava9ModulesArg to keep the first part of the Java 9 module
argument, and so remove static qualifier of addJvmArg.