### PR TITLE
Remove useless WARNING in log

### DIFF
--- a/capsule/src/main/java/Capsule.java
+++ b/capsule/src/main/java/Capsule.java
@@ -3495,7 +3495,7 @@ public class Capsule implements Runnable, InvocationHandler {
         if (res == null)
             throw new RuntimeException("Could not resolve " + x);
         if (res.isEmpty())
-            log(LOG_VERBOSE, "WARNING resolve " + x + " was empty");
+            log(LOG_VERBOSE, "resolve " + x + " was empty");
         return res;
     }
 


### PR DESCRIPTION
It is called when reolving native dependencies line 2512 and
when resolving boot classpath line 2281. And it happens that these
functionalities are not used, it is the case in our product, and it
still works perfectly. Nothing to be warned of...
